### PR TITLE
recvMsg reads past the end of the buffer

### DIFF
--- a/Network/Socket/Msg/CMsgHdr.hsc
+++ b/Network/Socket/Msg/CMsgHdr.hsc
@@ -106,9 +106,10 @@ cmsgExtractData :: Ptr CMsgHdr -> IO (Maybe B.ByteString)
 cmsgExtractData p = do
     let dataPtr = castPtr $ c_cmsg_data p
     dataLen <- cmsghdrLen <$> peek p
+    let dataSize = (fromIntegral dataLen) - (fromIntegral $ c_cmsg_len 0)
     if dataPtr == nullPtr
         then return Nothing
-        else return.Just =<< B.packCStringLen (dataPtr, fromIntegral dataLen)
+        else return.Just =<< B.packCStringLen (dataPtr, dataSize)
 
 peekCMsg :: Ptr CMsgHdr -> IO (Maybe CMsg)
 peekCMsg pCMsgHdr =


### PR DESCRIPTION
According to cmsg(3), `cmsg_len` includes header data and alignment, but the function `cmsgExtractData` from `Network/Socket/Msg/CMsgHdr.hsc` ignores that fact.
As a result, `recvMsg` always return some extra garbage data past the end of buffer.

A possible fix may be implemented this way:

```
diff --git a/Network/Socket/Msg/CMsgHdr.hsc b/Network/Socket/Msg/CMsgHdr.hsc
index 24bac7d..0d26c95 100644
--- a/Network/Socket/Msg/CMsgHdr.hsc
+++ b/Network/Socket/Msg/CMsgHdr.hsc
@@ -106,9 +106,10 @@ cmsgExtractData :: Ptr CMsgHdr -> IO (Maybe B.ByteString)
 cmsgExtractData p = do
     let dataPtr = castPtr $ c_cmsg_data p
     dataLen <- cmsghdrLen <$> peek p
+    let dataSize = (fromIntegral dataLen) - (fromIntegral $ c_cmsg_len 0)
     if dataPtr == nullPtr
         then return Nothing
-        else return.Just =<< B.packCStringLen (dataPtr, fromIntegral dataLen)
+        else return.Just =<< B.packCStringLen (dataPtr, dataSize)

 peekCMsg :: Ptr CMsgHdr -> IO (Maybe CMsg)
 peekCMsg pCMsgHdr =
```
